### PR TITLE
chore: bump zig pin 0.17.0-dev.1275 → 0.17.0-dev.1441 (align with zig-js)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: '0.17.0-dev.1275+59a628c6d'
+          version: '0.17.0-dev.1441+d5181a9c9'
 
       - name: Verify Zig Installation
         run: zig version
@@ -206,7 +206,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: '0.17.0-dev.1275+59a628c6d'
+          version: '0.17.0-dev.1441+d5181a9c9'
 
       - name: Check test pass-count vs baseline
         run: |
@@ -236,7 +236,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: '0.17.0-dev.1275+59a628c6d'
+          version: '0.17.0-dev.1441+d5181a9c9'
 
       - name: Run kernel memory tests
         run: |
@@ -290,7 +290,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: '0.17.0-dev.1275+59a628c6d'
+          version: '0.17.0-dev.1441+d5181a9c9'
 
       - name: Build Home Compiler
         run: zig build
@@ -319,7 +319,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: '0.17.0-dev.1275+59a628c6d'
+          version: '0.17.0-dev.1441+d5181a9c9'
 
       - name: Run filesystem tests
         run: |
@@ -337,7 +337,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: '0.17.0-dev.1275+59a628c6d'
+          version: '0.17.0-dev.1441+d5181a9c9'
 
       - name: Run network stack tests
         run: |

--- a/.github/workflows/conformance-gate.yml
+++ b/.github/workflows/conformance-gate.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: '0.17.0-dev.1275+59a628c6d'
+          version: '0.17.0-dev.1441+d5181a9c9'
 
       - name: Verify Zig installation
         run: zig version

--- a/.github/workflows/dataplane-bench.yml
+++ b/.github/workflows/dataplane-bench.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: '0.17.0-dev.1275+59a628c6d'
+          version: '0.17.0-dev.1441+d5181a9c9'
 
       - name: Verify Zig
         run: zig version

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: '0.17.0-dev.1275+59a628c6d'
+          version: '0.17.0-dev.1441+d5181a9c9'
 
       - name: Build Home Compiler
         run: zig build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: '0.17.0-dev.1275+59a628c6d'
+          version: '0.17.0-dev.1441+d5181a9c9'
 
       - name: Verify Zig Installation
         run: zig version

--- a/package.json
+++ b/package.json
@@ -71,6 +71,6 @@
     "commit-msg": "bunx gitlint --edit .git/COMMIT_EDITMSG"
   },
   "dependencies": {
-    "ziglang.org": "^0.17.0-dev.1275+59a628c6d"
+    "ziglang.org": "^0.17.0-dev.1441+d5181a9c9"
   }
 }

--- a/packages/comptime/home.toml
+++ b/packages/comptime/home.toml
@@ -9,4 +9,4 @@ authors = ["Home Contributors"]
 # No dependencies - pure compile-time code
 
 [build]
-zig_version = "0.17.0-dev.1275+59a628c6d"
+zig_version = "0.17.0-dev.1441+d5181a9c9"

--- a/pantry.json
+++ b/pantry.json
@@ -45,7 +45,7 @@
     "better-dx": "^0.2.15"
   },
   "dependencies": {
-    "ziglang.org": "0.17.0-dev.1275+59a628c6d"
+    "ziglang.org": "0.17.0-dev.1441+d5181a9c9"
   },
   "workspaces": [
     "./packages/vscode-home",

--- a/pantry.lock
+++ b/pantry.lock
@@ -2,9 +2,9 @@
   "version": "1.0.0",
   "lockfileVersion": 2,
   "packages": {
-    "ziglang.org@0.17.0-dev.1275+59a628c6d": {
+    "ziglang.org@0.17.0-dev.1441+d5181a9c9": {
       "name": "ziglang.org",
-      "version": "0.17.0-dev.1275+59a628c6d",
+      "version": "0.17.0-dev.1441+d5181a9c9",
       "source": "ziglang"
     }
   }

--- a/scripts/check-test-count.sh
+++ b/scripts/check-test-count.sh
@@ -25,7 +25,7 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 baseline_file="${repo_root}/docs/test-baseline.txt"
 log_file="${repo_root}/test-summary.log"
 count_file="${repo_root}/test-count.txt"
-expected_zig_version="0.17.0-dev.1275+59a628c6d"
+expected_zig_version="0.17.0-dev.1441+d5181a9c9"
 zig_bin="${repo_root}/pantry/.bin/zig"
 
 if [[ ! -x "${zig_bin}" ]]; then

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -9,7 +9,7 @@ set -uo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
-EXPECTED_ZIG_VERSION="0.17.0-dev.1275+59a628c6d"
+EXPECTED_ZIG_VERSION="0.17.0-dev.1441+d5181a9c9"
 ZIG="$ROOT/pantry/.bin/zig"
 
 if [[ -z "$ZIG" || ! -x "$ZIG" ]]; then

--- a/src/main.zig
+++ b/src/main.zig
@@ -5171,7 +5171,7 @@ fn initCommand(allocator: std.mem.Allocator, project_name: ?[]const u8) !void {
         \\# Project toolchain managed by pantry.
         \\# Run: home pkg tools
         \\dependencies:
-        \\  - ziglang.org@0.17.0-dev.1275+59a628c6d
+        \\  - ziglang.org@0.17.0-dev.1441+d5181a9c9
         \\  - bun
         \\
     ;
@@ -5381,7 +5381,7 @@ fn pkgInit(allocator: std.mem.Allocator) !void {
         \\# Project toolchain managed by pantry.
         \\# Run: home pkg tools
         \\dependencies:
-        \\  - ziglang.org@0.17.0-dev.1275+59a628c6d
+        \\  - ziglang.org@0.17.0-dev.1441+d5181a9c9
         \\  - bun
         \\
     ;

--- a/tools/ts_parity_snapshot.py
+++ b/tools/ts_parity_snapshot.py
@@ -59,7 +59,7 @@ from typing import Dict, Optional, Tuple
 # Sections we recognise. Order matters only for the human-readable diff
 # output; the JSON itself is sorted alphabetically per section.
 SECTIONS = ("smoke", "category", "baseline-aware", "diagnostic-codes")
-EXPECTED_ZIG_VERSION = "0.17.0-dev.1275+59a628c6d"
+EXPECTED_ZIG_VERSION = "0.17.0-dev.1441+d5181a9c9"
 
 # Lines look like:
 #   [ts_conformance smoke] comparable: total=13 passed=13 failed=0 skipped=0 pass_rate=1.00


### PR DESCRIPTION
## Why
zig-js moved to `0.17.0-dev.1441+d5181a9c9`, and Home will eventually consume zig-js — so align Home's toolchain pin to match, keeping the two in sync.

## Verified locally (macos-arm64)
The 166-commit jump 1275→1441 has **no breaking changes** for Home:
- `zig build debug` compiles with **zero errors**
- resulting binary runs clean across every path:
  - Home-language: `home run examples/hello.home` → `Hello, Home!`
  - JSC runtime: `home test test/js/node/path/basename.test.js` → 4/0
  - CLI run-flag path: `parse_args/default-args.test.mjs` → 8/0

## What changed (exact version-string swap, 19 refs / 13 files)
- `pantry.json` / `pantry.lock` (pkgx-style lock — no embedded hashes to regen)
- `package.json`, `packages/comptime/home.toml`
- 5 CI workflows (`mlugg/setup-zig` version): release, conformance-gate, fuzz-nightly, ci, dataplane-bench
- version-guard scripts: `run_tests.sh`, `check-test-count.sh`, `tools/ts_parity_snapshot.py`
- doctor/help text in `src/main.zig`

## What this PR's CI adds
Local proof was macos-arm64 only — **CI here validates the full platform matrix under 1441**. Safe to merge once green.